### PR TITLE
loki.enabled -> loki.enable

### DIFF
--- a/modules/monitoring/nginx.nix
+++ b/modules/monitoring/nginx.nix
@@ -65,7 +65,7 @@
           config.secshell.monitoring.domains.pushgateway
         ]
         ++ (lib.optionals config.services.grafana.enable [ config.secshell.monitoring.domains.grafana ])
-        ++ (lib.optionals config.services.loki.enabled [ config.secshell.monitoring.domains.loki ]);
+        ++ (lib.optionals config.services.loki.enable [ config.secshell.monitoring.domains.loki ]);
     };
   };
 }


### PR DESCRIPTION
Follow up to #2, looks like the key was not `config.services.loki.enabled`, but rather `config.services.loki.enable`